### PR TITLE
FixSearch: add useful keywords to search in preferences

### DIFF
--- a/com.cubrid.common.ui/plugin.xml
+++ b/com.cubrid.common.ui/plugin.xml
@@ -171,20 +171,50 @@
              id="com.cubrid.common.ui.preference.queryoption"
              category="com.cubrid.common.ui.preference.category"
              name="%queryOptionPageName">
+			<keywordReference id="Query.commit"/>
+			<keywordReference id="Query.result"/>
+			<keywordReference id="Query.CLOB"/>
+			<keywordReference id="Query.BLOB"/>
+			<keywordReference id="Query.prompt"/>
+			<keywordReference id="Query.keyword"/>
+			<keywordReference id="Query.scientific"/>
+			<keywordReference id="Query.font"/>
        </page>
        <page
              class="com.cubrid.common.ui.common.preference.JdbcManagePreferencePage"
              id="com.cubrid.common.ui.preference.jdbcmanage"
              category="com.cubrid.common.ui.preference.category"
              name="%jdbcManagePageName">
+			<keywordReference id="Jdbc.update"/>
+			<keywordReference id="Jdbc.add"/>
+			<keywordReference id="Jdbc.delete"/>
        </page>
        <page
              category="com.cubrid.common.ui.preference.category"
              class="com.cubrid.common.ui.cubrid.table.preference.ImportPreferencePage"
              id="com.cubrid.common.ui.preference.ImportPreferencePage"
              name="%importOptions">
+			<keywordReference id="Import.null"/>
+			<keywordReference id="Import.export"/>
+			<keywordReference id="Import.import"/>
        </page>
     </extension>
+	<extension point="org.eclipse.ui.keywords">
+		<keyword label="commit" id="Query.commit"/>
+		<keyword label="result" id="Query.result"/>
+		<keyword label="CLOB" id="Query.CLOB"/>
+		<keyword label="BLOB" id="Query.BLOB"/>
+		<keyword label="prompt" id="Query.prompt"/>
+		<keyword label="keyword" id="Query.keyword"/>
+		<keyword label="scientific" id="Query.scientific"/>
+		<keyword label="font" id="Query.font"/>
+		<keyword label="update" id="Jdbc.update"/>
+		<keyword label="add" id="Jdbc.add"/>
+		<keyword label="delete" id="Jdbc.delete"/>
+		<keyword label="null" id="Import.null"/>
+		<keyword label="export" id="Import.export"/>
+		<keyword label="import" id="Import.import"/>
+	</extension>
     <extension
           point="org.eclipse.ui.views">
        <category

--- a/com.cubrid.cubridmanager.app/plugin.xml
+++ b/com.cubrid.cubridmanager.app/plugin.xml
@@ -81,6 +81,24 @@
              class="com.cubrid.common.ui.common.preference.GeneralPreferencePage"
              id="com.cubrid.common.ui.preference.general"
              name="%prefTitleGeneral">
+			<keywordReference id="General.prompt"/>
+			<keywordReference id="General.information"/>
+			<keywordReference id="General.CUBRID"/>
+			<keywordReference id="General.update"/>
+			<keywordReference id="General.layout"/>
+			<keywordReference id="General.query"/>
+			<keywordReference id="General.editor"/>
+			<keywordReference id="General.completion"/>
        </page>
     </extension>
+	<extension point="org.eclipse.ui.keywords">
+  		<keyword label="prompt" id="General.prompt"/>
+		<keyword label="information" id="General.information"/>
+		<keyword label="CUBRID" id="General.CUBRID"/>
+		<keyword label="update" id="General.update"/>
+		<keyword label="layout" id="General.layout"/>
+		<keyword label="query" id="General.query"/>
+		<keyword label="editor" id="General.editor"/>
+		<keyword label="completion" id="General.completion"/>
+	</extension>   
 </plugin>

--- a/com.cubrid.cubridmanager.ui/plugin.xml
+++ b/com.cubrid.cubridmanager.ui/plugin.xml
@@ -131,8 +131,14 @@
              class="com.cubrid.cubridmanager.ui.mondashboard.preference.DashboardPreferencePage"
              id="com.cubrid.cubridmanager.ui.preference.mondashboard"
              name="%monitorDashboardEditorName">
+			<keywordReference id="Dashboard.color"/>
+			<keywordReference id="Dashboard.heartbeat"/>
        </page>
     </extension>
+	<extension point="org.eclipse.ui.keywords">
+		<keyword label="color" id="Dashboard.color"/>
+		<keyword label="heartbeat" id="Dashboard.heartbeat"/>
+	</extension>
     <extension
           point="org.eclipse.ui.views">
        <category


### PR DESCRIPTION
The search box in the preferences widget was using only the names of the tabs as keywords. I have added useful search keywords for every individual tab, making the search box more useful.