### PR TITLE
ShowDashboard: add \n to message so it splits

### DIFF
--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/common/Messages.properties
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/common/Messages.properties
@@ -540,7 +540,7 @@ errCanNotSaveFileIntoFavorite=Can't save into Favorites.\nError: {0}
 errDuplicatedNameFavorite=Duplicate file name in the workspace. Please input new one.
 errSaveFailedFavorite=There is failed to save the file. Please try again later.
 #Show dashboard dialog
-btnShowDashboard=Show this dashboard whenever it is connected
+btnShowDashboard=Show this dashboard\nwhenever it is connected
 lblShowDashboard=Show:
 lblAutoRefreshSecond=Refresh:
 lblAutoRefreshSecondUnit=Second


### PR DESCRIPTION

![dash](https://cloud.githubusercontent.com/assets/17722852/21427636/6939943c-c85e-11e6-949c-fccd1484f279.png)
The message is too big for this unresizable window. Adding a \n splits this message and it looks ok now.
![dash2](https://cloud.githubusercontent.com/assets/17722852/21427657/819d7a52-c85e-11e6-8003-129037a00d52.png)
